### PR TITLE
#5 Call stacks

### DIFF
--- a/html/debug.html
+++ b/html/debug.html
@@ -31,7 +31,7 @@ abbr {text-decoration: none;}
         </td>
     </tr>
     <tr>
-        <td rowspan="2" width="25%" style="padding-right:40px;">
+        <td rowspan="3" width="25%" style="padding-right:40px;">
             <h2>Functions</h1>
             <select id="function-drop" style="width:100%;"><option>(All)</option></select><br/>
             <input id="function-text" style="margin-top:5px;width:100%;" type="text" placeholder="Filter (using regex)" />
@@ -47,11 +47,11 @@ abbr {text-decoration: none;}
             <h2>Variables</h2>
             <ul id="function-variables"></ul>
         </td>
+    </tr>
+    <tr id="function-depends-section">
         <td>
-            <!--
             <h2>Calls</h2>
-            Call stack
-            -->
+            <ul id="function-depends"</ul>
         </td>
     </tr>
 </table>

--- a/html/debug.js
+++ b/html/debug.js
@@ -101,6 +101,7 @@ function showCallStack(me)
         cursor = temp;
         for(i in depends)
             cursor.append($(depends[i]));
+        $("#function-depends-section").show();
     }
  }
 function renderCall(i)

--- a/html/debug.js
+++ b/html/debug.js
@@ -145,7 +145,8 @@ function init()
 {
     var funcNames = [];
     for (var i = 0; i < trace.functions.length; i++)
-        funcNames.push(trace.functions[i].name);
+        if(!funcNames.includes(trace.functions[i].name))
+            funcNames.push(trace.functions[i].name);
     funcNames = funcNames.sort();
     var drop = $("#function-drop");
     for (var i = 0; i < funcNames.length; i++)

--- a/html/debug.js
+++ b/html/debug.js
@@ -39,17 +39,55 @@ function showCall(i)
         }
     }
     $("#function-variables").empty();
+    $("#function-depends").empty();
     var variables = [];
+    var depends = [];
+    var seenDepends = false;
     for (var s in t)
     {
         if (s == "") continue;
-        variables.push(s + " = " + trace.variables[t[s]]);
+        if (s == "$depends") {
+            showDepends(t[s]);
+            seenDepends = true;
+        }
+        else
+            variables.push(s + " = " + trace.variables[t[s]]);
     }
+    if(!seenDepends)
+        $("#function-depends-section").hide();
     variables = variables.sort();
     for (var i = 0; i < variables.length; i++)
         $("#function-variables").append($("<li>" + escapeHTML(variables[i]) + "</li>"));
 }
 
+function showDepends(s)
+{
+    var i;
+    for(i in s) {
+         var msg = renderCall(s[i]);
+         $("#function-depends").append($("<li><a href='javascript:showCall(" + s[i] + ")'>" + escapeHTML(msg) + "</a></li>"));
+
+     }
+ }
+function renderCall(i)
+{
+     var t = trace.calls[i];
+     var inf = trace.functions[t[""]];
+     var words = [];
+     words.push(inf.name);
+     for (var j = 0; j < inf.arguments.length; j++)
+        {
+            var v = inf.arguments[j];
+            if (v in t)
+                words.push(trace.variables[t[v]]);
+            else
+                words.push("_");
+        }
+     words.push("=");
+     words.push(trace.variables[t[inf.result]]);
+     var msg = words.join(" ");
+     return msg;
+}
 function showCalls()
 {
     var name = $("#function-drop").val();
@@ -63,22 +101,7 @@ function showCalls()
     var ul = $("#function-list").empty();
     for (var i = 0; i < trace.calls.length; i++)
     {
-        var t = trace.calls[i];
-        var inf = trace.functions[t[""]];
-        if (name != "(All)" && name != inf.name) continue;
-        var words = [];
-        words.push(inf.name);
-        for (var j = 0; j < inf.arguments.length; j++)
-        {
-            var v = inf.arguments[j];
-            if (v in t)
-                words.push(trace.variables[t[v]]);
-            else
-                words.push("_");
-        }
-        words.push("=");
-        words.push(trace.variables[t[inf.result]]);
-        var msg = words.join(" ");
+        var msg = renderCall(i);
         if (!regex.test(msg)) continue;
         ul.append($("<li><a href='javascript:showCall(" + i + ")'>" + escapeHTML(msg) + "</a></li>"));
     }


### PR DESCRIPTION
This adds support for call stacks in the frontend (the json schema has been extended accordingly).

Paired with [debug-hoed](https://github.com/pepeiborra/debug-hoed), call stacks looks like [this](https://rawgit.com/pepeiborra/debug-hoed/master/example/quicksort.html) for the quicksort example.

The default backend should still work, although it won't display call stacks. I am not planning on extending it though, as I prefer to focus on `debug-hoed`.