### PR TITLE
Improvements 

### DIFF
--- a/debug.cabal
+++ b/debug.cabal
@@ -45,7 +45,8 @@ library
         uniplate,
         unordered-containers,
         js-jquery,
-        ansi-wl-pprint,
+        prettyprinter,
+        prettyprinter-compat-ansi-wl-pprint,
         vector
 
     exposed-modules:

--- a/debug.cabal
+++ b/debug.cabal
@@ -37,6 +37,7 @@ library
         aeson,
         ghc-prim,
         extra,
+        deepseq,
         directory,
         hashable,
         template-haskell,

--- a/html/debug.js
+++ b/html/debug.js
@@ -53,7 +53,7 @@ function showCall(i)
     }
     variables = variables.sort();
     for (var i = 0; i < variables.length; i++)
-        $("#function-variables").append($("<li>" + escapeHTML(variables[i]) + "</li>"));
+        $("#function-variables").append($("<li><pre>" + escapeHTML(variables[i]) + "</pre></li>"));
 }
 
 function showCallStack(me)

--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -94,8 +94,8 @@ adjustDec askSig o@(FunD name clauses@(Clause arity _ _:_))
     let clauses2 = map addTag $ transformBi (adjustValD tag) clauses
     let args2 = [VarE 'var `AppE` VarE tag `AppE` toLitPre "$" a `AppE` VarE a | a <- args]
     let info = ConE 'Function `AppE`
-            (packLit $ toLit name) `AppE`
-            (packLit $ LitE (StringL $ prettyPrint $ maybeToList (askSig name) ++ [o])) `AppE`
+            packLit (toLit name) `AppE`
+            packLit (LitE (StringL $ prettyPrint $ maybeToList (askSig name) ++ [o])) `AppE`
             ListE (map (packLit . toLitPre "$") args) `AppE`
             packLit (LitE (StringL "$result"))
     let body2 = VarE 'var `AppE` VarE tag `AppE` LitE (StringL "$result") `AppE` foldl AppE (VarE inner) (VarE tag : args2)
@@ -105,7 +105,7 @@ adjustDec askSig o@(FunD name clauses@(Clause arity _ _:_))
 adjustDec askSig x = return x
 
 transformApps :: Name -> [Clause] -> Q [Clause]
-transformApps tag clauses = mapM (appsFromClause tag) clauses
+transformApps tag = mapM (appsFromClause tag)
 
 appsFromClause :: Name -> Clause -> Q Clause
 appsFromClause tag cl@(Clause pats body decs) = do

--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -56,6 +56,7 @@ import Control.Monad.Extra
 import Data.Generics.Uniplate.Data
 import Data.List.Extra
 import Data.Maybe
+import Data.Text (pack)
 import Debug.Record
 import Debug.Util
 import Language.Haskell.TH
@@ -93,10 +94,10 @@ adjustDec askSig o@(FunD name clauses@(Clause arity _ _:_))
     let clauses2 = map addTag $ transformBi (adjustValD tag) clauses
     let args2 = [VarE 'var `AppE` VarE tag `AppE` toLitPre "$" a `AppE` VarE a | a <- args]
     let info = ConE 'Function `AppE`
-            toLit name `AppE`
-            LitE (StringL $ prettyPrint $ maybeToList (askSig name) ++ [o]) `AppE`
-            ListE (map (toLitPre "$") args) `AppE`
-            LitE (StringL "$result")
+            (packLit $ toLit name) `AppE`
+            (packLit $ LitE (StringL $ prettyPrint $ maybeToList (askSig name) ++ [o])) `AppE`
+            ListE (map (packLit . toLitPre "$") args) `AppE`
+            packLit (LitE (StringL "$result"))
     let body2 = VarE 'var `AppE` VarE tag `AppE` LitE (StringL "$result") `AppE` foldl AppE (VarE inner) (VarE tag : args2)
     let body = VarE 'funInfo `AppE` info `AppE` LamE [VarP tag] body2
     afterApps <- transformApps tag clauses2
@@ -182,6 +183,7 @@ adjustPat tag x = x
 
 toLit = toLitPre ""
 toLitPre pre (Name (OccName x) _) = LitE $ StringL $ pre ++ x
+packLit = AppE (VarE 'pack)
 
 hasRankNTypes (ForallT vars ctxt typ) = hasRankNTypes' typ
 hasRankNTypes typ = hasRankNTypes' typ

--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -85,7 +85,7 @@ adjustDec askSig o@(FunD name clauses@(Clause arity _ _:_)) = do
     tag <- newName "tag"
     args <- sequence [newName $ "arg" ++ show i | i <- [1 .. length arity]]
     let addTag (Clause ps bod inner) = Clause (VarP tag:ps) bod inner
-    let clauses2 = map addTag $ transformBi (adjustPat tag) clauses
+    let clauses2 = map addTag $ transformBi (adjustValD tag) clauses
     let args2 = [VarE 'var `AppE` VarE tag `AppE` toLitPre "$" a `AppE` VarE a | a <- args]
     let info = ConE 'Function `AppE`
             toLit name `AppE`
@@ -168,6 +168,8 @@ infixExpDisplayName e =
 prettyPrint = pprint . transformBi f
     where f (Name x _) = Name x NameS -- avoid nasty qualifications
 
+adjustValD tag decl@ValD{} = transformBi (adjustPat tag) decl
+adjustValD tag other       = other
 adjustPat :: Name -> Pat -> Pat
 adjustPat tag (VarP x) = ViewP (VarE 'var `AppE` VarE tag `AppE` toLit x) (VarP x)
 adjustPat tag x = x

--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -45,7 +45,7 @@
 --   @TemplateHaskell@) see "Debug.Record".
 module Debug(
     -- * Generate trace
-    debug,
+    debug, debugRun,
     -- * View a trace
     debugView, debugSave, debugPrint,
     -- * Clear a trace

--- a/src/Debug/Record.hs
+++ b/src/Debug/Record.hs
@@ -14,6 +14,7 @@ module Debug.Record(
     Call,
     funInfo, fun, var,
     debugClear,
+    debugRun,
     -- * Viewing
     debugPrint, debugPrintTrace,
     debugJSON, debugJSONTrace,
@@ -89,6 +90,14 @@ debugClear = do
 --   in a human-readable format.
 debugPrint :: IO ()
 debugPrint = getDebugTrace >>= debugPrintTrace
+
+-- | Run a computation and open a browser window showing observed function calls.
+--
+--   @ main = debugRun $ do
+--       ...
+--   @
+debugRun :: IO a -> IO a
+debugRun = bracket_ debugClear debugView
 
 -- | Print information about the observed function calls to 'stdout',
 --   in a human-readable format.

--- a/src/Debug/Record.hs
+++ b/src/Debug/Record.hs
@@ -271,7 +271,8 @@ getDebugTrace = do
   return $ DebugTrace infos (map T.pack vars) callEntries
 
 instance FromJSON DebugTrace
-instance ToJSON DebugTrace
+instance ToJSON DebugTrace where
+  toEncoding = genericToEncoding defaultOptions
 
 -- | A flat encoding of an observed call.
 data CallData = CallData
@@ -303,6 +304,14 @@ instance ToJSON CallData where
     ["$depends" .= toJSON callDepends | not(null callDepends)] ++
     ["$parents" .= toJSON callParents | not(null callParents)] ++
     map (uncurry (.=)) callVals
+  toEncoding CallData{..} = pairs ("" .= callFunctionId <> depends <> parents)
+    where
+      depends
+        | null callDepends = mempty
+        | otherwise = "$depends" .= callDepends
+      parents
+        | null callParents = mempty
+        | otherwise = "$parents" .= callParents
 
 functionJsonOptions = defaultOptions{fieldLabelModifier = f}
     where
@@ -314,3 +323,4 @@ instance FromJSON Function where
 
 instance ToJSON Function where
     toJSON = genericToJSON functionJsonOptions
+    toEncoding = genericToEncoding functionJsonOptions

--- a/src/Debug/Record.hs
+++ b/src/Debug/Record.hs
@@ -201,7 +201,7 @@ instance {-# OVERLAPS #-} Show a where
 #endif
 
 {-# NOINLINE fun #-}
--- | Called under a lambda with a function name to provide a unique conpretty for
+-- | Called under a lambda with a function name to provide a unique context for
 --   a particular call, e.g.:
 --
 -- > tracedAdd x y = fun "add" $ \t -> var t "x" x + var t "y" y

--- a/src/Debug/Record.hs
+++ b/src/Debug/Record.hs
@@ -29,6 +29,7 @@ module Debug.Record(
     ) where
 
 import Debug.Variables
+import Control.DeepSeq
 import Control.Exception
 import Control.Monad
 import Data.Aeson
@@ -72,6 +73,7 @@ data Function = Function
     deriving (Eq,Generic,Ord,Show)
 
 instance Hashable Function
+instance NFData Function
 
 -- | A single function call, used to attach additional information
 data Call = Call Function (IORef [(Text, Var)])
@@ -273,6 +275,7 @@ getDebugTrace = do
 instance FromJSON DebugTrace
 instance ToJSON DebugTrace where
   toEncoding = genericToEncoding defaultOptions
+instance NFData DebugTrace
 
 -- | A flat encoding of an observed call.
 data CallData = CallData
@@ -282,6 +285,8 @@ data CallData = CallData
   , callParents :: [Int]        -- ^ Indexes into the 'calls' table
   }
   deriving (Eq, Generic, Show)
+
+instance NFData CallData
 
 instance FromJSON CallData where
   parseJSON (Object v) =

--- a/src/Debug/Record.hs
+++ b/src/Debug/Record.hs
@@ -3,8 +3,10 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- Dodgy Show instance, useful for debugging
+{-# OPTIONS_GHC -Wno-deprecations #-} -- Dodgy Show instance, useful for debugging
 
 -- | Module for recording and manipulating debug traces. For most users, the
 --   @TemplateHaskell@ helpers in "Debug" should be sufficient.
@@ -38,6 +40,8 @@ import Data.IORef
 import Data.List.Extra
 import Data.Maybe
 import Data.Monoid
+import Data.Text (Text)
+import Data.Text.Read as T
 import Data.Tuple.Extra
 import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.HashMap.Strict as HM
@@ -53,23 +57,24 @@ import Text.Show.Functions() -- Make sure the Show for functions instance exists
 import qualified Language.Javascript.JQuery as JQuery
 import Web.Browser
 import Paths_debug
+--import Data.Text.Prettyprint.Doc.Render.Text
 import Text.PrettyPrint.ANSI.Leijen as PP hiding ((<$>), (<>))
 import Text.Read
 
 
 -- | Metadata about a function, used to drive the HTML view.
 data Function = Function
-    {funName :: String -- ^ Function name
-    ,funSource :: String -- ^ Function source, using @\n@ to break lines
-    ,funArguments :: [String] -- ^ Variables for the arguments to the function
-    ,funResult :: String -- ^ Variable for the result of the function
+    {funName :: Text -- ^ Function name
+    ,funSource :: Text -- ^ Function source, using @\n@ to break lines
+    ,funArguments :: [Text] -- ^ Variables for the arguments to the function
+    ,funResult :: Text -- ^ Variable for the result of the function
     }
     deriving (Eq,Generic,Ord,Show)
 
 instance Hashable Function
 
 -- | A single function call, used to attach additional information
-data Call = Call Function (IORef [(String, Var)])
+data Call = Call Function (IORef [(Text, Var)])
 
 {-# NOINLINE refVariables #-}
 refVariables :: IORef Variables
@@ -110,40 +115,40 @@ debugPrintTrace DebugTrace{..} = do
         docs = map call $ nubOrd $ reverse concs
     putDoc (vcat docs <> hardline)
     where
-          call :: (Function, [(String, String)]) -> Doc
+          call :: (Function, [(Text, Text)]) -> Doc
           call (f, vs) =
                    let ass = vs
                        hdr = bold $ header ass f
                    in hang 5 $ hdr <$$> body ass
 
 
-          header :: [(String, String)] -> Function -> Doc
-          header ass f = text "\n*"       <+>
-                         text (funName f) <+>
+          header :: [(Text, Text)] -> Function -> Doc
+          header ass f = "\n*"       <+>
+                         pretty (funName f) <+>
                          arguments ass    <+>
-                         text "="         <+>
+                         "="         <+>
                          result ass
 
-          arguments :: [(String, String)] -> Doc
+          arguments :: [(Text, Text)] -> Doc
           arguments ass =
                 let vals = map snd
                          $ sortOn fst
                          $ mapMaybe (\(t, v) -> (,v) <$> getArgIndex t)
                            ass
-                in hsep (map text vals)
+                in hsep (map pretty vals)
 
-          result :: [(String, String)] -> Doc
-          result = text . fromMaybe "no result!" . lookup "$result"
+          result :: [(Text, Text)] -> Doc
+          result = pretty . fromMaybe "no result!" . lookup "$result"
 
-          body :: [(String, String)] -> Doc
+          body :: [(Text, Text)] -> Doc
           body svs = vsep $ map bodyLine svs
 
-          bodyLine :: (String, String) -> Doc
-          bodyLine (t, v) = text t <+> text "=" <+> text v
+          bodyLine :: (Text, Text) -> Doc
+          bodyLine (t, v) = pretty t <+> "=" <+> pretty v
 
           -- getArgIndex $arg19 = Just 19
-          getArgIndex :: String -> Maybe Int
-          getArgIndex ('$':'a':'r':'g':rest) = readMaybe(takeWhile isDigit rest)
+          getArgIndex :: Text -> Maybe Int
+          getArgIndex (T.stripPrefix "$arg" -> Just rest) = case T.decimal(T.takeWhile isDigit rest) of Left e -> Nothing ; Right(i,rest) -> Just i
           getArgIndex _ = Nothing
 
 -- | Save information about observed functions to the specified file, in HTML format.
@@ -194,7 +199,7 @@ instance {-# OVERLAPS #-} Show a where
 #endif
 
 {-# NOINLINE fun #-}
--- | Called under a lambda with a function name to provide a unique context for
+-- | Called under a lambda with a function name to provide a unique conpretty for
 --   a particular call, e.g.:
 --
 -- > tracedAdd x y = fun "add" $ \t -> var t "x" x + var t "y" y
@@ -202,7 +207,7 @@ instance {-# OVERLAPS #-} Show a where
 --   This function involves giving identity to function calls, so is unsafe,
 --   and will only work under a lambda.
 fun :: Show a => String -> (Call -> a) -> a
-fun name = funInfo $ Function name [] [] []
+fun name = funInfo $ Function (T.pack name) "" [] ""
 
 -- | A version of 'fun' allowing you to pass further information about the
 --   'Function' which is used when showing debug views.
@@ -219,7 +224,7 @@ funInfo info f = unsafePerformIO $ do
 var :: Show a => Call -> String -> a -> a
 var (Call _ ref) name val = unsafePerformIO $ do
     var <- atomicModifyIORef refVariables $ addVariable val
-    atomicModifyIORef ref $ \v -> ((name, var):v, ())
+    atomicModifyIORef ref $ \v -> ((T.pack name, var) :v, ())
     return val
 
 ---------------------------------
@@ -242,7 +247,7 @@ debugJSONTrace = encode
 -- | A flat encoding of debugging observations.
 data DebugTrace = DebugTrace
   { functions :: [Function]  -- ^ Flat list of all the functions traced
-  , variables :: [String]    -- ^ Flat list of all the variable values observed
+  , variables :: [Text]    -- ^ Flat list of all the variable values observed
   , calls     :: [CallData]  -- ^ Flat list of all the function calls traced
   }
   deriving (Eq, Generic, Show)
@@ -263,7 +268,7 @@ getDebugTrace = do
           callDepends = [] -- available in the Hoed backend but not in this one
           callParents = [] -- available in the Hoed backend but not in this one
       return CallData{..}
-  return $ DebugTrace infos vars callEntries
+  return $ DebugTrace infos (map T.pack vars) callEntries
 
 instance FromJSON DebugTrace
 instance ToJSON DebugTrace
@@ -271,7 +276,7 @@ instance ToJSON DebugTrace
 -- | A flat encoding of an observed call.
 data CallData = CallData
   { callFunctionId :: Int       -- ^ An index into the 'functions' table
-  , callVals :: [(String, Int)] -- ^ The value name tupled with an index into the 'variables' table
+  , callVals :: [(Text, Int)] -- ^ The value name tupled with an index into the 'variables' table
   , callDepends :: [Int]        -- ^ Indexes into the 'calls' table
   , callParents :: [Int]        -- ^ Indexes into the 'calls' table
   }
@@ -283,7 +288,7 @@ instance FromJSON CallData where
     where
       vals =
         sequence
-          [ (T.unpack k, ) <$> parseJSON x
+          [ (k, ) <$> parseJSON x
           | (k, x) <- HM.toList v
           , not(T.null k)
           , k /= "$depends"
@@ -297,7 +302,7 @@ instance ToJSON CallData where
     "" .= callFunctionId :
     ["$depends" .= toJSON callDepends | not(null callDepends)] ++
     ["$parents" .= toJSON callParents | not(null callParents)] ++
-    map (uncurry (.=) . first T.pack) callVals
+    map (uncurry (.=)) callVals
 
 functionJsonOptions = defaultOptions{fieldLabelModifier = f}
     where


### PR DESCRIPTION
Summary
----------
I used [debug-pp](pepeiborra/debug-pp) to instrument hlint with [debug-hoed](pepeiborra/debug-hoed) and `debug` (although I'm no longer able to instrument hlint with debug). During the process I ran into some issues and performance bottlenecks, which I've tried to address in this PR.

Changes
----------
- Switch to `Text` - debug traces can get pretty large and something more compact than String is required; we need `Text` to generate JSON anyway, so it seems like the obvious choice. Not user visible anyway.
- Added `debugRun` - a wrapper for the `main` function that opens a web browser after the program is run.
- Format call variables using `<pre>` for slightly nicer rendering and newline preservation
- Fixes for the handling of var bindings in the TH wrapper - do we really want to wrap them all or only the lhss of `where` clauses ?
- Fixes for the handling of type signatures - I don't think it is possible to add partial constraints (or `Show` constraints for that matter) to rank-2 arguments without breaking the callers.
- Improved performance of `toJSON` implementations.