### PR TITLE
Update to Hoed 0.5.0

### DIFF
--- a/debug.cabal
+++ b/debug.cabal
@@ -43,7 +43,7 @@ library
         aeson,
         containers,
         ghc-prim,
-        Hoed >= 0.4.1 && < 0.5,
+        Hoed >= 0.5,
         libgraph >= 1.14,
         extra,
         deepseq,

--- a/src/Debug/Hoed.hs
+++ b/src/Debug/Hoed.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeOperators     #-}
 {-# LANGUAGE ViewPatterns      #-}
-{-# OPTIONS -Wno-orphans       #-}
+
 -- | An alternative backend for lazy debugging with call stacks built on top of the "Hoed" package.
 --
 --   Instrumentation is done via a TH wrapper, which requires the following extensions:
@@ -143,12 +143,6 @@ data HoedCallDetails = HoedCallDetails
   , depends, parents :: ![HoedCallKey]
   } deriving (Eq, Generic, Hashable)
 
--- XXX Remove these orphan instances when a version of Hoed with them is released
-instance Hashable Vertex where
-  hashWithSalt s RootVertex    = s `hashWithSalt` (-1 :: Int)
-  hashWithSalt s (Vertex cs _) = s `hashWithSalt` cs
-instance Hashable CompStmt where
-  hashWithSalt s cs = hashWithSalt s (stmtIdentifier cs)
 
 ---------------------------------------------------------------------------
 -- Cached pred and succ relationships
@@ -185,12 +179,12 @@ getRelatives rel v =
 extractHoedCall :: AnnotatedCompTree -> Vertex -> Maybe (Hashed HoedFunctionKey, HoedCallKey, HoedCallDetails)
 extractHoedCall hoedCompTree v@Vertex {vertexStmt = c@CompStmt {stmtDetails = StmtLam {..}, ..}} =
   Just
-    ( hashed $ HoedFunctionKey (pack stmtLabel) (length stmtLamArgs) (map fst clauses)
+    ( hashed $ HoedFunctionKey (stmtLabel) (length stmtLamArgs) (map fst clauses)
     , stmtIdentifier
-    , HoedCallDetails (map (hashed . pack) stmtLamArgs) (map snd clauses) (hashed (pack stmtLamRes)) depends parents)
+    , HoedCallDetails stmtLamArgs (map snd clauses) stmtLamRes depends parents)
   where
     clauses =
-      [ (pack stmtLabel, hashed (pack stmtCon))
+      [ (stmtLabel, stmtCon)
       | Vertex {vertexStmt = CompStmt {stmtLabel, stmtDetails = StmtCon {..}}} <-
           getSuccs hoedCompTree v
       ]
@@ -342,7 +336,7 @@ debug' Config{..} q = do
             let Just n' = lookup n names
                 label = createLabel n dec
             newDecl <-
-              funD n [clause [] (normalB [|observe label $(varE n')|]) []]
+              funD n [clause [] (normalB [|observe (pack label) $(varE n')|]) []]
             let clauses' = transformBi adjustValD clauses
             return [newDecl, ValD (VarP n') b clauses']
         FunD n clauses
@@ -350,7 +344,7 @@ debug' Config{..} q = do
             let Just n' = lookup n names
                 label = createLabel n dec
             newDecl <-
-              funD n [clause [] (normalB [|observe label $(varE n')|]) []]
+              funD n [clause [] (normalB [|observe (pack label) $(varE n')|]) []]
             let clauses' = transformBi (adjustInnerSigD . adjustValD) clauses
             return [newDecl, FunD n' clauses']
         SigD n ty
@@ -418,7 +412,7 @@ adjustValD decl@ValD{} = transformBi adjustPat decl
 adjustValD other       = other
 
 adjustPat :: Pat -> Pat
-adjustPat (VarP x) = ViewP (VarE 'observe `AppE` toLit x) (VarP x)
+adjustPat (VarP x) = ViewP (VarE 'observe `AppE` (VarE 'pack `AppE` toLit x)) (VarP x)
 adjustPat x        = x
 
 toLit :: Name -> Exp


### PR DESCRIPTION
Hoed 0.5.0 switches to `Text`, adds missing `Hashable` instances and missing docs for the `Observable` class.