### PR TITLE
Restricted number of shadowed variables

### DIFF
--- a/src/Debug/Variables.hs
+++ b/src/Debug/Variables.hs
@@ -200,22 +200,26 @@ var (Call _ ref) name val = unsafePerformIO $ do
     when (show val /= "<function>") $ do -- these make the variable list long without providing useful info
         var <- atomicModifyIORef refVariables $ addVariable val
         name' <- unShadowName ref $ pack name
-        atomicModifyIORef ref $ \v -> ((name', var) :v, ())
+        whenJust name' (\n -> atomicModifyIORef ref $ \v -> ((n, var) :v, ()))
     return val
 
 -- | If a name is already being used, find the next available name by adding ' (prime) chars until
 --   the resulting name is unique
-unShadowName :: IORef [(Text, Var)] -> Text -> IO Text
+unShadowName :: IORef [(Text, Var)] -> Text -> IO (Maybe Text)
 unShadowName ioRef t = do
     pairs <- readIORef ioRef
     let matches = filter (isPrefixPrime t) $ map fst pairs
+    let shadowedLimit = 3
     if not (null matches)
         then do
             let lengths = map T.length matches
             let zipped = zip matches lengths
-            let maxName = fst $ fromJust $ find (\p -> snd p == maximum lengths) zipped
-            return $ maxName `T.append` "'"
-        else return t
+            let maxLen = maximum lengths
+            let maxName = fst $ fromJust $ find (\p -> snd p == maxLen) zipped
+            case length matches of    -- --i.e., case (the number of (')s)
+                n | n > shadowedLimit  -> return Nothing
+                _                      -> return $ Just $ maxName `T.append` "'"
+        else return $ Just t
 
 -- | Is the second string equal to the first plus some number of ' (prime) characters?
 -- | e.g. x `isPrefixPrime` x' == true, x isPrefixPrime x'' == True, but x isPrefixPrime xs == False

--- a/src/Debug/Variables.hs
+++ b/src/Debug/Variables.hs
@@ -203,7 +203,7 @@ var (Call _ ref) name val = unsafePerformIO $ do
         whenJust name' (\n -> atomicModifyIORef ref $ \v -> ((n, var) :v, ()))
     return val
 
--- | If a name is already being used, find the next available name by adding ' (prime) chars until
+-- | If a name is already used, find the next available name by adding ' (prime) chars until
 --   the resulting name is unique
 unShadowName :: IORef [(Text, Var)] -> Text -> IO (Maybe Text)
 unShadowName ioRef t = do

--- a/test/Variables.hs
+++ b/test/Variables.hs
@@ -202,6 +202,27 @@ where_1_vars =
     , ("z", "5")
     , ("z'", "7") ]
 
+debug [d|
+    where_2 :: [Int] -> [Int]
+    where_2 xs = fmap f xs where
+        f x = x * x
+    |]
+
+where_2_vars :: [(Text, Text)]
+where_2_vars =
+    [ ("$arg1", "[1,2,3,4,5,6,7,8,9]")
+    , ("$result", "[1,4,9,16,25,36,49,64,81]")
+    , ("*", "1")
+    , ("*'", "4")
+    , ("*''", "9")
+    , ("*'''", "16")
+    , ("fmap", "[1,4,9,16,25,36,49,64,81]")
+    , ("x", "1")
+    , ("x'", "2")
+    , ("x''", "3")
+    , ("x'''", "4")
+    , ("xs", "[1,2,3,4,5,6,7,8,9]") ]
+
 explicit :: (Ord a, Show a) => [a] -> [a]
 explicit = quicksort'
     where
@@ -257,7 +278,8 @@ expectedVars = [ ("quicksort", quicksort_vars)
                , ("case_test", case_test_vars)
                , ("twoXs", twoXs_vars)
                , ("manyXs", manyXs_vars)
-               , ("where_1", where_1_vars) ]
+               , ("where_1", where_1_vars)
+               , ("where_2", where_2_vars) ]
 
 main = do
     createDirectoryIfMissing True "output"
@@ -268,6 +290,7 @@ main = do
     testExample "twoXs" (twoXs [2,3,4] [7,8,9]) False
     testExample "manyXs" (manyXs [2,3,4] [7,8,9]) False
     testExample "where_1" (where_1 5 7) False
+    testExample "where_2" (where_2 [1,2,3,4,5,6,7,8,9]) False
 
     --skipping test of quicksortBy for now, as it looks like $arg1 is missing
     testExample "quicksortBy" (quicksortBy (<) "haskell") True


### PR DESCRIPTION
The 'shadowed' variables are limited to three copies, i.e., x, x', x'', x'''

Its still an open issue to somehow display that the number of values displayed has been truncated.