### PR TITLE
Update Hoed dependency

### DIFF
--- a/debug.cabal
+++ b/debug.cabal
@@ -44,7 +44,7 @@ library
         aeson,
         containers,
         ghc-prim,
-        Hoed >= 0.5,
+        Hoed >= 0.5.1,
         libgraph >= 1.14,
         extra,
         deepseq,


### PR DESCRIPTION
Hoed has been released with GHC 8.4 comp fixes